### PR TITLE
Fix det_prob_threshold in compreface detector test

### DIFF
--- a/api/src/util/detectors/compreface.js
+++ b/api/src/util/detectors/compreface.js
@@ -23,7 +23,7 @@ module.exports.recognize = async ({ key, test }) => {
       return true;
     },
     params: {
-      det_prob_threshold: test ? 0 : DET_PROB_THRESHOLD,
+      det_prob_threshold: test ? 0.8 : DET_PROB_THRESHOLD,
     },
     data: formData,
   });


### PR DESCRIPTION
Changed det_prob_threshold from 0 to 0.8 when testing the compreface detector to address issue with compreface custom-builds.