### PR TITLE
FEAT: Support Frigate sub labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ detect:
 frigate:
   url:
 
+  # if double-take should send matches back to frigate as a sub label
+  # NOTE: requires frigate 0.11.0+ (default: shown below)
+  update_sub_labels: false
+
   # object labels that are allowed for facial recognition
   labels:
     - person

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "double-take-api",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "double-take-api",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@mhoc/axios-digest-auth": "^0.8.0",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "double-take-api",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Unified UI and API for processing and training images for facial recognition",
   "scripts": {
     "start": "node server.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "double-take-frontend",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "double-take-frontend",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "ace-builds": "^1.4.13",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "double-take-frontend",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Unified UI and API for processing and training images for facial recognition",
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "double-take",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "double-take",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^13.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "double-take",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Unified UI and API for processing and training images for facial recognition",
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
I added a [PR over at Frigate](https://github.com/blakeblackshear/frigate/pull/2949) to support setting sub labels. This will allow double-take to update the `Person` label to be `Person: Nick` (for example). 

This is a WIP and I am still trying to figure out how to add this to double-take as I am new to working with it. @jakowenko if you have any recommendations on where to insert this logic that would be much appreciated. 