### PR TITLE
Skip Frigate matches below an area target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,11 @@ frigate:
   # stop the processing loop if a match is found
   # if set to false all image attempts will be processed before determining the best match
   stop_on_match: true
+  
+  # ignore detected areas so small that face recognition would be difficult
+  # quadrupling the min_area of the detector is a good start
+  # does not apply to MQTT events
+  min_area: 0
 
   # object labels that are allowed for facial recognition
   labels:

--- a/api/src/constants/config.js
+++ b/api/src/constants/config.js
@@ -134,6 +134,7 @@ module.exports.frigate = ({ id, camera, topic }) => {
     attempts,
     image,
     stop_on_match: stopOnMatch,
+    min_area: minArea,
   } = JSON.parse(JSON.stringify(CONFIG.frigate));
   const { masks } = module.exports;
 
@@ -152,5 +153,6 @@ module.exports.frigate = ({ id, camera, topic }) => {
     url: { frigate: url, snapshot, latest },
     attempts,
     stop_on_match: stopOnMatch,
+    min_area: minArea,
   });
 };

--- a/api/src/constants/defaults.js
+++ b/api/src/constants/defaults.js
@@ -27,6 +27,7 @@ module.exports = {
     labels: ['person'],
     update_sub_labels: false,
     stop_on_match: true,
+    min_area: 0,
   },
   mqtt: {
     topics: {

--- a/api/src/controllers/recognize.controller.js
+++ b/api/src/controllers/recognize.controller.js
@@ -58,8 +58,8 @@ module.exports.start = async (req, res) => {
     if (event.type === 'frigate') {
       const { type: frigateEventType, topic } = req.body;
       const attributes = req.body.after ? req.body.after : req.body.before;
-      const { id, label, camera, current_zones: zones } = attributes;
-      event = { id, label, camera, zones, frigateEventType, topic, ...event };
+      const { id, label, camera, area, current_zones: zones } = attributes;
+      event = { id, label, camera, area, zones, frigateEventType, topic, ...event };
     } else {
       const { url, camera } = req.query;
 

--- a/api/src/util/frigate.util.js
+++ b/api/src/util/frigate.util.js
@@ -64,12 +64,12 @@ module.exports.checks = async ({
       return `${id} - ${label} label not in (${FRIGATE.LABELS.join(', ')})`;
     }
 
-    if (IDS.includes(id)) {
-      return `already processed ${id}`;
-    }
-
     if (FRIGATE.MIN_AREA > area) {
       return `skipping object area smaller than ${FRIGATE.MIN_AREA} (${area})`;
+    }
+
+    if (IDS.includes(id)) {
+      return `already processed ${id}`;
     }
 
     await frigate.status(topic);

--- a/api/src/util/frigate.util.js
+++ b/api/src/util/frigate.util.js
@@ -22,6 +22,7 @@ module.exports.checks = async ({
   topic,
   label,
   camera,
+  area,
   zones,
   PROCESSING,
   IDS,
@@ -65,6 +66,10 @@ module.exports.checks = async ({
 
     if (IDS.includes(id)) {
       return `already processed ${id}`;
+    }
+
+    if (FRIGATE.MIN_AREA > area) {
+      return `skipping object area smaller than ${FRIGATE.MIN_AREA} (${area})`;
     }
 
     await frigate.status(topic);


### PR DESCRIPTION
With certain camera setups it's easy to get into a situation where you get lots of person detections that are too small to ever lead to face detections. If you're using Rekognition, this can get a bit spendy.

I think it may be possible to apply this to MQTT payloads as well, but since those don't come with an area pre-stamped, it would have been a lot more work, and this really gets it most of the way there. If anyone is very sensitive to this problem, MQTT can always be turned off.