### PR TITLE
Enable secure connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,20 +280,27 @@ token:
 ```yaml
 # enable mqtt subscribing and publishing (default: shown below)
 mqtt:
+  protocol: mqtt
   host:
+  port: 1883
   username:
   password:
   client_id:
 
+  # only used when secure protocols such as mqtts (uses port 8883 by default) are used
   tls:
-    # cert chains in PEM format: /path/to/client.crt
-    cert:
-    # private keys in PEM format: /path/to/client.key
-    key:
-    # optionally override the trusted CA certificates: /path/to/ca.crt
+    # list of trusted CA certificates: /path/to/ca.crt
     ca:
-    # if true the server will reject any connection which is not authorized with the list of supplied CAs
+    # double-take will reject any connection to a server which is 
+    # identified with a certificate not found on the supplied CAs list.
+    # set this to disable it, MitM risk, use only for testing.
     reject_unauthorized: false
+
+    # only needed for tls client authentication, cert chain in PEM format: /path/to/client.crt
+    cert:
+    # only needed for tls client authentication, private key in PEM format: /path/to/client.key
+    key:
+
 
   topics:
     # mqtt topic for frigate message subscription

--- a/api/src/constants/defaults.js
+++ b/api/src/constants/defaults.js
@@ -30,6 +30,8 @@ module.exports = {
     min_area: 0,
   },
   mqtt: {
+    protocol: 'mqtt',
+    port: 1883,
     tls: {
       reject_unauthorized: false,
     },

--- a/api/src/util/mqtt.util.js
+++ b/api/src/util/mqtt.util.js
@@ -88,15 +88,19 @@ module.exports.connect = () => {
   if (!MQTT || !MQTT.HOST) return;
 
   try {
-    CLIENT = mqtt.connect(`mqtt://${MQTT.HOST}`, {
+    CLIENT = mqtt.connect({
       reconnectPeriod: 10000,
+      protocol: MQTT.PROTOCOL,
+      host: MQTT.HOST,
+      port: MQTT.PORT,
       username: MQTT.USERNAME || MQTT.USER,
       password: MQTT.PASSWORD || MQTT.PASS,
       clientId: MQTT.CLIENT_ID || `double-take-${Math.random().toString(16).substr(2, 8)}`,
       key: MQTT.TLS.KEY ? filesystem.readFileSync(MQTT.TLS.KEY) : null,
       cert: MQTT.TLS.CERT ? filesystem.readFileSync(MQTT.TLS.CERT) : null,
-      ca: MQTT.TLS.CA ? filesystem.readFileSync(MQTT.TLS.CA) : null,
       rejectUnauthorized: MQTT.TLS.REJECT_UNAUTHORIZED === true,
+      // The CA list will be used to determine if server is authorized
+      ca: MQTT.TLS.CA ? filesystem.readFileSync(MQTT.TLS.CA) : null,
     });
 
     CLIENT.on('connect', () => {


### PR DESCRIPTION
This fixes #294.

Users may have been using TLS configuration without realizing plain MQTT was being used regardless.
Maybe put up a warning on the next release?